### PR TITLE
Change world to refer to Solver rather than GSolver

### DIFF
--- a/cannon.d.ts
+++ b/cannon.d.ts
@@ -930,7 +930,7 @@
         gravity: Vec3;
         broadphase: NaiveBroadphase;
         bodies: Body[];
-        solver: GSSolver;
+        solver: Solver;
         constraints: Constraint[];
         narrowPhase: NarrowPhase;
         collisionMatrix: ArrayCollisionMatrix;


### PR DESCRIPTION
Hi, I think the world should refer to the base Solver class rather than the more specific GSSolver. 

For example without this change the cannon sample threejs_fps.html would not compile when converted to typescript e.g.

``` javascript
            function initCannon(){
                // Setup our world
                world = new CANNON.World();
                world.quatNormalizeSkip = 0;
                world.quatNormalizeFast = false;

                var solver = new CANNON.GSSolver();

                world.defaultContactMaterial.contactEquationStiffness = 1e9;
                world.defaultContactMaterial.contactEquationRegularizationTime = 4;

                solver.iterations = 7;
                solver.tolerance = 0.1;
                var split = true;
                if(split)
                    // THIS WOULD FAIL AS IT'S NOT A GSSOLVER
                    world.solver = new CANNON.SplitSolver(solver);
                else
                    world.solver = solver;
```
